### PR TITLE
chore: release v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoship",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI tool to automate changeset-based releases with AI-generated descriptions",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.1 for npm release

## Test plan
- Build passes
- All 71 tests pass