### PR TITLE
feat: add agent-friendly skill structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # Agent Instructions
 
+## Using autoship
+
+For instructions on using the autoship CLI tool, see `skills/autoship/SKILL.md`.
+
+## Code Style
+
+- Do not use emojis in code, output, or documentation. Unicode symbols are acceptable.
+- Use TypeScript for all source files.
+- Use ES modules (`import`/`export`), not CommonJS.
+- Prefer `async`/`await` over raw promises.
+
 ## Package Management
 
 **Always check the latest version before installing a package.**

--- a/README.md
+++ b/README.md
@@ -98,6 +98,40 @@ npx autoship list
 
 Config is stored at `~/.autoship/config.json`.
 
+## Usage with AI Agents
+
+### Just ask the agent
+
+The simplest approach - just tell your agent to use it:
+
+```
+Use autoship to release my package. Run autoship --help to see available commands.
+```
+
+### AI Coding Assistants
+
+Add the skill to your AI coding assistant for richer context:
+
+```bash
+npx skills add vercel-labs/autoship
+```
+
+This works with Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, Goose, OpenCode, and Windsurf.
+
+### AGENTS.md / CLAUDE.md
+
+For more consistent results, add to your project or global instructions file:
+
+```markdown
+## Package Releases
+
+Use `autoship` for releases. Run `autoship --help` for all commands.
+
+Core workflow:
+1. `autoship add <name>` - Configure repository (one-time)
+2. `autoship <name> -t patch -y` - Automated release
+```
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/skills/autoship/SKILL.md
+++ b/skills/autoship/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: autoship
+description: CLI tool for automated changeset-based releases with AI-generated descriptions. Use when the user needs to release a package, create changesets, bump versions, or automate npm publishing workflows. Triggers include requests to "release a package", "create a changeset", "publish to npm", "bump the version", "automate releases", or any task involving version management and package publishing for repositories using the changesets workflow.
+allowed-tools: Bash(autoship:*), Bash(npx autoship:*)
+---
+
+# Automated Releases with autoship
+
+## Core Workflow
+
+Every release follows this pattern:
+
+1. **Configure**: `autoship add <name>` (one-time setup)
+2. **Release**: `autoship <name>` (interactive) or `autoship <name> -t patch -y` (automated)
+
+The tool handles the complete release cycle:
+- Clone repository
+- Analyze changes and suggest release type (patch/minor/major)
+- Generate AI-powered changeset description
+- Create and merge changeset PR
+- Wait for and merge Version Packages PR
+- Trigger npm publish
+
+## Requirements
+
+Before using autoship, ensure:
+
+```bash
+# GitHub CLI must be authenticated
+gh auth login
+
+# API key for AI features
+export AI_GATEWAY_API_KEY="your-key"
+```
+
+## Essential Commands
+
+```bash
+# One-time setup: add a repository
+autoship add myproject
+# Prompts for: owner, repo name, base branch
+
+# List configured repositories
+autoship list
+
+# Interactive release (prompts for type and message)
+autoship myproject
+
+# Automated release (no prompts)
+autoship myproject -t patch -y
+autoship myproject -t minor -y
+autoship myproject -t major -y
+
+# Release with custom message (skips AI generation)
+autoship myproject -t patch -m "Fixed login bug" -y
+```
+
+## Command Options
+
+```bash
+autoship [repo]                    # Interactive repo selection if omitted
+  -t, --type <type>                # Release type: patch, minor, major
+  -m, --message <message>          # Custom changeset description
+  -y, --yes                        # Skip all confirmations
+  -h, --help                       # Show help
+```
+
+## Common Patterns
+
+### Fully Automated Patch Release
+
+```bash
+autoship myproject -t patch -y
+```
+
+### AI-Assisted Interactive Release
+
+```bash
+autoship myproject
+# 1. AI analyzes commits since last release
+# 2. AI suggests release type (patch/minor/major)
+# 3. You confirm or change the type
+# 4. AI generates changeset description
+# 5. You review and approve
+# 6. Tool handles PR creation and merging
+```
+
+### Custom Message Release
+
+```bash
+autoship myproject -t minor -m "Added new authentication providers" -y
+```
+
+### CI/CD Integration
+
+```bash
+# In GitHub Actions or CI pipeline
+export AI_GATEWAY_API_KEY="${{ secrets.AI_GATEWAY_API_KEY }}"
+npx autoship myproject -t patch -y
+```
+
+## What autoship Does (10 Steps)
+
+1. **Clone** - Clones the repository from the base branch
+2. **Analyze** - Finds latest version tag, analyzes commits and diff
+3. **Suggest** - AI suggests release type based on changes
+4. **Generate** - AI generates changeset description
+5. **Branch** - Creates release branch with changeset file
+6. **PR** - Creates pull request for the changeset
+7. **Wait** - Waits for CI checks to pass
+8. **Merge** - Merges the changeset PR
+9. **Version PR** - Waits for changesets action to create Version Packages PR
+10. **Publish** - Merges Version Packages PR to trigger npm publish
+
+## Output Format
+
+autoship provides clear step-by-step output:
+
+```
+[1/10] Cloning repository from main...
+  > Repository cloned
+  > Package: my-package @ 1.2.3
+
+[2/10] Creating release branch...
+  > Branch created: release/patch-1706123456789
+
+[3/10] Generating changeset...
+  > Changeset created: fluffy-pants-dance.md
+
+...
+
+Release Complete!
+The patch release has been published.
+```
+
+## Configuration
+
+Config is stored at `~/.autoship/config.json`:
+
+```json
+{
+  "repos": {
+    "myproject": {
+      "owner": "vercel-labs",
+      "repo": "myproject",
+      "baseBranch": "main",
+      "cloneUrl": "https://github.com/vercel-labs/myproject.git"
+    }
+  }
+}
+```
+
+## Deep-Dive Documentation
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/commands.md](references/commands.md) | Full command reference with all options |
+| [references/configuration.md](references/configuration.md) | Config file format and repository setup |
+| [references/ci-integration.md](references/ci-integration.md) | GitHub Actions and CI/CD setup |
+
+## Ready-to-Use Templates
+
+| Template | Description |
+|----------|-------------|
+| [templates/automated-release.sh](templates/automated-release.sh) | Fully automated release script |
+| [templates/setup-repo.sh](templates/setup-repo.sh) | Non-interactive repository setup |
+
+```bash
+./templates/automated-release.sh myproject patch
+./templates/setup-repo.sh myproject vercel-labs myproject main
+```
+
+## Troubleshooting
+
+### "No repositories configured"
+
+Run `autoship add <name>` to configure a repository first.
+
+### "Repository not found"
+
+Check `autoship list` for available repos. The name is case-sensitive.
+
+### CI checks failing
+
+The tool will show which checks failed. Fix the issues in the target repository, then retry.
+
+### AI generation failed
+
+If AI fails, autoship falls back to manual input. Ensure `AI_GATEWAY_API_KEY` is set.

--- a/skills/autoship/references/ci-integration.md
+++ b/skills/autoship/references/ci-integration.md
@@ -1,0 +1,211 @@
+# CI/CD Integration
+
+Run autoship in CI/CD pipelines for fully automated releases.
+
+## GitHub Actions
+
+### Scheduled Releases
+
+Release on a schedule (e.g., weekly):
+
+```yaml
+name: Scheduled Release
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository to release'
+        required: true
+        type: string
+      type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: pnpm/action-setup@v2
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      
+      - name: Install autoship
+        run: pnpm add -g autoship
+      
+      - name: Configure repository
+        run: |
+          mkdir -p ~/.autoship
+          echo '${{ secrets.AUTOSHIP_CONFIG }}' > ~/.autoship/config.json
+      
+      - name: Run release
+        env:
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          autoship ${{ inputs.repo || 'myproject' }} \
+            -t ${{ inputs.type || 'patch' }} \
+            -y
+```
+
+### Trigger on Label
+
+Release when a PR is labeled:
+
+```yaml
+name: Release on Label
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  release:
+    if: contains(github.event.label.name, 'release:')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: pnpm/action-setup@v2
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      
+      - name: Determine release type
+        id: type
+        run: |
+          LABEL="${{ github.event.label.name }}"
+          if [[ "$LABEL" == "release:major" ]]; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif [[ "$LABEL" == "release:minor" ]]; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Install and run autoship
+        env:
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          pnpm add -g autoship
+          mkdir -p ~/.autoship
+          echo '${{ secrets.AUTOSHIP_CONFIG }}' > ~/.autoship/config.json
+          autoship myproject -t ${{ steps.type.outputs.type }} -y
+```
+
+## Environment Variables
+
+Set these secrets in your CI environment:
+
+| Secret | Description |
+|--------|-------------|
+| `AI_GATEWAY_API_KEY` | API key for AI features |
+| `GH_TOKEN` | GitHub token with repo access (or use `GITHUB_TOKEN`) |
+| `AUTOSHIP_CONFIG` | Contents of `~/.autoship/config.json` |
+
+### Creating AUTOSHIP_CONFIG Secret
+
+```bash
+# Copy your local config to clipboard
+cat ~/.autoship/config.json | pbcopy  # macOS
+cat ~/.autoship/config.json | xclip   # Linux
+
+# Add as secret in GitHub repo settings
+```
+
+## Best Practices
+
+### 1. Use Workflow Dispatch for Manual Triggers
+
+Always include `workflow_dispatch` for manual triggering:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+```
+
+### 2. Pin autoship Version
+
+For reproducible builds, pin the version:
+
+```yaml
+- run: pnpm add -g autoship@1.0.0
+```
+
+### 3. Validate Before Release
+
+Add a validation step:
+
+```yaml
+- name: Validate
+  run: |
+    # Ensure we have changes to release
+    if git diff --quiet HEAD $(git describe --tags --abbrev=0); then
+      echo "No changes since last release"
+      exit 0
+    fi
+```
+
+### 4. Notify on Completion
+
+```yaml
+- name: Notify
+  if: success()
+  run: |
+    curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+      -H "Content-Type: application/json" \
+      -d '{"text": "Released ${{ inputs.repo }} (${{ inputs.type }})"}'
+```
+
+## Troubleshooting CI
+
+### "gh: command not found"
+
+Install GitHub CLI in your workflow:
+
+```yaml
+- name: Install GitHub CLI
+  run: |
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt update
+    sudo apt install gh
+```
+
+Or use the official action:
+
+```yaml
+- uses: cli/cli-action@v1
+```
+
+### "Authentication required"
+
+Ensure `GH_TOKEN` is set and has sufficient permissions:
+
+```yaml
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+```
+
+The token needs `repo` scope for private repositories.

--- a/skills/autoship/references/commands.md
+++ b/skills/autoship/references/commands.md
@@ -1,0 +1,104 @@
+# Command Reference
+
+Complete reference for all autoship commands. For quick start and common patterns, see SKILL.md.
+
+## Main Command
+
+```bash
+autoship [repo] [options]
+```
+
+If `repo` is omitted, displays an interactive selector with all configured repositories.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-t, --type <type>` | Release type: `patch`, `minor`, or `major` |
+| `-m, --message <message>` | Custom changeset description (skips AI generation) |
+| `-y, --yes` | Skip all confirmation prompts |
+| `-h, --help` | Show help |
+| `-V, --version` | Show version |
+
+### Examples
+
+```bash
+# Interactive mode - prompts for everything
+autoship myproject
+
+# Specify release type, AI generates message
+autoship myproject -t minor
+
+# Fully automated with custom message
+autoship myproject -t patch -m "Fixed login validation" -y
+
+# Fully automated with AI message
+autoship myproject -t patch -y
+```
+
+## add Command
+
+Add a new repository configuration.
+
+```bash
+autoship add <name>
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `name` | Friendly name for the repository (used in other commands) |
+
+### Interactive Prompts
+
+1. **GitHub owner** - Organization or username (required)
+2. **Repository name** - GitHub repository name (defaults to `name`)
+3. **Base branch** - Branch to release from (defaults to `main`)
+
+### Example
+
+```bash
+autoship add myproject
+# > GitHub owner (org or user): vercel-labs
+# > Repository name: myproject
+# > Base branch: main
+# Repository "myproject" added!
+# Clone URL: https://github.com/vercel-labs/myproject.git
+```
+
+## list Command
+
+List all configured repositories.
+
+```bash
+autoship list
+```
+
+### Output
+
+```
+Configured repositories:
+  - myproject (vercel-labs/myproject)
+  - another-lib (vercel-labs/another-lib)
+```
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `AI_GATEWAY_API_KEY` | API key for AI-powered suggestions and descriptions | Yes |
+| `GITHUB_TOKEN` | GitHub token (uses `gh` CLI auth by default) | No |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (see output for details) |
+
+Common error scenarios:
+- Repository not configured
+- GitHub CLI not authenticated
+- CI checks failed
+- AI API unavailable (falls back to manual input)

--- a/skills/autoship/references/configuration.md
+++ b/skills/autoship/references/configuration.md
@@ -1,0 +1,124 @@
+# Configuration Reference
+
+autoship stores configuration in `~/.autoship/config.json`.
+
+## Config File Structure
+
+```json
+{
+  "repos": {
+    "<name>": {
+      "owner": "<github-owner>",
+      "repo": "<github-repo>",
+      "baseBranch": "<branch>",
+      "cloneUrl": "<clone-url>"
+    }
+  }
+}
+```
+
+## Repository Configuration
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `owner` | string | GitHub organization or username |
+| `repo` | string | GitHub repository name |
+| `baseBranch` | string | Branch to create releases from (typically `main`) |
+| `cloneUrl` | string | HTTPS clone URL (auto-generated) |
+
+### Example
+
+```json
+{
+  "repos": {
+    "ai-sdk": {
+      "owner": "vercel",
+      "repo": "ai",
+      "baseBranch": "main",
+      "cloneUrl": "https://github.com/vercel/ai.git"
+    },
+    "agent-browser": {
+      "owner": "vercel-labs",
+      "repo": "agent-browser",
+      "baseBranch": "main",
+      "cloneUrl": "https://github.com/vercel-labs/agent-browser.git"
+    }
+  }
+}
+```
+
+## Managing Configuration
+
+### Add Repository (Recommended)
+
+Use the CLI to add repositories:
+
+```bash
+autoship add myproject
+```
+
+This interactively prompts for all required fields.
+
+### Manual Editing
+
+You can also edit `~/.autoship/config.json` directly:
+
+```bash
+# Open config file
+$EDITOR ~/.autoship/config.json
+```
+
+### Remove Repository
+
+Currently, remove repositories by editing the config file directly:
+
+```bash
+# Edit and remove the entry from "repos"
+$EDITOR ~/.autoship/config.json
+```
+
+## Requirements for Target Repositories
+
+autoship works with repositories that use the [changesets](https://github.com/changesets/changesets) workflow:
+
+1. **Changesets installed** - `@changesets/cli` as dev dependency
+2. **Changesets config** - `.changeset/config.json` exists
+3. **Changesets GitHub Action** - Configured to create Version Packages PRs
+4. **Version tags** - Repository uses version tags (e.g., `v1.2.3`, `package@1.2.3`)
+
+### Typical Target Repository Setup
+
+```bash
+# In the target repository
+pnpm add -D @changesets/cli
+npx changeset init
+```
+
+`.github/workflows/release.yml`:
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - uses: changesets/action@v1
+        with:
+          publish: pnpm release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```

--- a/skills/autoship/templates/automated-release.sh
+++ b/skills/autoship/templates/automated-release.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Template: Automated Release
+# Purpose: Fully automated release with no prompts
+# Usage: ./automated-release.sh <repo-name> <release-type> [message]
+#
+# Examples:
+#   ./automated-release.sh myproject patch
+#   ./automated-release.sh myproject minor
+#   ./automated-release.sh myproject major "Breaking API changes"
+
+set -euo pipefail
+
+REPO="${1:?Usage: $0 <repo-name> <release-type> [message]}"
+TYPE="${2:?Usage: $0 <repo-name> <release-type> [message]}"
+MESSAGE="${3:-}"
+
+# Validate release type
+if [[ ! "$TYPE" =~ ^(patch|minor|major)$ ]]; then
+  echo "Error: release type must be patch, minor, or major"
+  exit 1
+fi
+
+# Check requirements
+if ! command -v gh &> /dev/null; then
+  echo "Error: GitHub CLI (gh) is required"
+  echo "Install: https://cli.github.com"
+  exit 1
+fi
+
+if ! gh auth status &> /dev/null; then
+  echo "Error: GitHub CLI not authenticated"
+  echo "Run: gh auth login"
+  exit 1
+fi
+
+if [[ -z "${AI_GATEWAY_API_KEY:-}" ]]; then
+  echo "Error: AI_GATEWAY_API_KEY environment variable not set"
+  exit 1
+fi
+
+# Run autoship
+echo "Starting $TYPE release for $REPO..."
+
+if [[ -n "$MESSAGE" ]]; then
+  autoship "$REPO" -t "$TYPE" -m "$MESSAGE" -y
+else
+  autoship "$REPO" -t "$TYPE" -y
+fi
+
+echo "Release complete!"

--- a/skills/autoship/templates/setup-repo.sh
+++ b/skills/autoship/templates/setup-repo.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Template: Non-interactive Repository Setup
+# Purpose: Add a repository without interactive prompts
+# Usage: ./setup-repo.sh <name> <owner> <repo> [base-branch]
+#
+# Examples:
+#   ./setup-repo.sh myproject vercel-labs myproject
+#   ./setup-repo.sh myproject vercel-labs myproject main
+#   ./setup-repo.sh ai-sdk vercel ai main
+
+set -euo pipefail
+
+NAME="${1:?Usage: $0 <name> <owner> <repo> [base-branch]}"
+OWNER="${2:?Usage: $0 <name> <owner> <repo> [base-branch]}"
+REPO="${3:?Usage: $0 <name> <owner> <repo> [base-branch]}"
+BASE_BRANCH="${4:-main}"
+
+CONFIG_DIR="$HOME/.autoship"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+
+# Create config directory if needed
+mkdir -p "$CONFIG_DIR"
+
+# Initialize config file if needed
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo '{"repos":{}}' > "$CONFIG_FILE"
+fi
+
+# Check if jq is available for JSON manipulation
+if command -v jq &> /dev/null; then
+  # Use jq for proper JSON handling
+  CLONE_URL="https://github.com/$OWNER/$REPO.git"
+  
+  jq --arg name "$NAME" \
+     --arg owner "$OWNER" \
+     --arg repo "$REPO" \
+     --arg branch "$BASE_BRANCH" \
+     --arg url "$CLONE_URL" \
+     '.repos[$name] = {owner: $owner, repo: $repo, baseBranch: $branch, cloneUrl: $url}' \
+     "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+  
+  echo "Repository '$NAME' added!"
+  echo "  Owner: $OWNER"
+  echo "  Repo: $REPO"
+  echo "  Branch: $BASE_BRANCH"
+  echo "  Clone URL: $CLONE_URL"
+else
+  # Fallback: use autoship add with expect-like input
+  echo "Warning: jq not found, using interactive fallback"
+  echo "Install jq for non-interactive setup: brew install jq"
+  echo ""
+  echo "Running: autoship add $NAME"
+  echo "Please enter:"
+  echo "  Owner: $OWNER"
+  echo "  Repo: $REPO"
+  echo "  Branch: $BASE_BRANCH"
+  autoship add "$NAME"
+fi


### PR DESCRIPTION
## Summary

Makes autoship more agent-friendly by adding a skill structure similar to agent-browser.

## Changes

- **`skills/autoship/SKILL.md`** - Main skill file with YAML frontmatter (`name`, `description`, `allowed-tools`) for AI assistants
- **`skills/autoship/references/`** - Deep-dive documentation:
  - `commands.md` - Full command reference
  - `configuration.md` - Config file format and repo requirements
  - `ci-integration.md` - GitHub Actions workflows
- **`skills/autoship/templates/`** - Ready-to-use shell scripts:
  - `automated-release.sh` - Fully automated release
  - `setup-repo.sh` - Non-interactive repo setup
- **`AGENTS.md`** - Updated with code style guidelines for contributors
- **`README.md`** - Added "Usage with AI Agents" section

## Usage

Agents can now be given context via:

```bash
npx skills add vercel-labs/autoship
```

Or by pointing them to `skills/autoship/SKILL.md` directly.