### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoship",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "CLI tool to automate changeset-based releases with AI-generated descriptions",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps version to 0.2.0 for npm publish.

## Changes
- Agent-friendly skill structure added in previous PR

Merging this will trigger npm publish.