### PR TITLE
chore: add .npmignore to exclude dev files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# Source files (dist/ is published)
+src/
+
+# Config files
+tsconfig.json
+vitest.config.ts
+
+# Dev files
+*.test.ts
+.github/


### PR DESCRIPTION
Excludes dev files from the published npm package:

- `src/` - Source files (dist/ is published instead)
- `*.test.ts` - Test files
- `tsconfig.json`, `vitest.config.ts` - Dev config

Reduces package size from 44.3 kB to 30.1 kB.